### PR TITLE
Release version 0.9.0 of cnd

### DIFF
--- a/.github/workflows/create-cnd-gh-release.yml
+++ b/.github/workflows/create-cnd-gh-release.yml
@@ -13,6 +13,9 @@ jobs:
     name: Create cnd GitHub release
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout sources to access local actions
+        uses: actions/checkout@v2
+
       - name: Extract version from branch name
         id: extract-version
         uses: ./.github/actions/extract-version-from-branch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "cnd"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cnd/CHANGELOG.md
+++ b/cnd/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [cnd-0.9.0] - 2020-09-22
+
 ### Added
 
 -   A set of API endpoints that expose the decentralized orderbook functionality.
@@ -144,7 +146,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Move config files to standard location based on platform (OSX, Windows, Linux).
 -   Align implementation with RFC-002 to use the decision header instead of status codes.
 
-[Unreleased]: https://github.com/comit-network/comit-rs/compare/0.8.0...HEAD
+[Unreleased]: https://github.com/thomaseizinger/comit-rs/compare/cnd-0.9.0...HEAD
+
+[cnd-0.9.0]: https://github.com/thomaseizinger/comit-rs/compare/0.8.0...cnd-0.9.0
 
 [0.8.0]: https://github.com/comit-network/comit-rs/compare/0.7.3...0.8.0
 

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["CoBloX developers <team@coblox.tech>"]
 name = "cnd"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 description = "Reference implementation of a COMIT network daemon."
 


### PR DESCRIPTION
Hi @thomaseizinger!

This PR was created in response to a manual trigger of the release workflow here: https://github.com/thomaseizinger/comit-rs/actions/runs/267771748.
I've updated the changelog and bumped the versions in the manifest files in this commit: a2f973bfb7ef02b277f91338fb91dc1749128022.

Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.