### PR TITLE
Merge `release/cnd/0.9.0` into `dev`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "cnd"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cnd/CHANGELOG.md
+++ b/cnd/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [cnd-0.9.0] - 2020-09-22
+
 ### Added
 
 -   A set of API endpoints that expose the decentralized orderbook functionality.
@@ -144,7 +146,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Move config files to standard location based on platform (OSX, Windows, Linux).
 -   Align implementation with RFC-002 to use the decision header instead of status codes.
 
-[Unreleased]: https://github.com/comit-network/comit-rs/compare/0.8.0...HEAD
+[Unreleased]: https://github.com/thomaseizinger/comit-rs/compare/cnd-0.9.0...HEAD
+
+[cnd-0.9.0]: https://github.com/thomaseizinger/comit-rs/compare/0.8.0...cnd-0.9.0
 
 [0.8.0]: https://github.com/comit-network/comit-rs/compare/0.7.3...0.8.0
 

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["CoBloX developers <team@coblox.tech>"]
 name = "cnd"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 description = "Reference implementation of a COMIT network daemon."
 


### PR DESCRIPTION
This PR merges the `release/cnd/0.9.0` branch back into `dev`.
This happens to ensure that the updates that happend on the release branch, i.e. CHANGELOG and manifest updates are also present on the dev branch.