### PR TITLE
Merge `release/nectar/0.2.0` into `dev`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "nectar"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/nectar/CHANGELOG.md
+++ b/nectar/CHANGELOG.md
@@ -7,4 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/comit-network/comit-rs/compare/d5d26e42a2d8dd026ae94f2c8a9e0bd80ab81133...HEAD
+## [nectar-0.2.0] - 2020-09-22
+
+[Unreleased]: https://github.com/thomaseizinger/comit-rs/compare/nectar-0.2.0...HEAD
+
+[nectar-0.2.0]: https://github.com/thomaseizinger/comit-rs/compare/e2b2b78c821246ce483c75ab2702b58615bbd370...nectar-0.2.0

--- a/nectar/Cargo.toml
+++ b/nectar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nectar"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["CoBloX Team <team@coblox.tech>"]
 edition = "2018"
 


### PR DESCRIPTION
This PR merges the `release/nectar/0.2.0` branch back into `dev`.
This happens to ensure that the updates that happend on the release branch, i.e. CHANGELOG and manifest updates are also present on the dev branch.